### PR TITLE
Added 'cmd-9 goes to last tab' action

### DIFF
--- a/SafariTabSwitching/SafariTabSwitching.m
+++ b/SafariTabSwitching/SafariTabSwitching.m
@@ -33,10 +33,22 @@
                 && [keyWindow respondsToSelector:@selector(setCurrentTabViewItem:)])
             {
                 NSArray *tabs = [keyWindow performSelector:@selector(orderedTabViewItems)];
-                if (tabs.count >= (tabIndex + 1))
+                NSInteger newTabIndex = -1;
+                
+                if (tabIndex == 8)
                 {
-                    [keyWindow performSelector:@selector(setCurrentTabViewItem:) withObject:[tabs objectAtIndex:tabIndex]];
+                    newTabIndex = tabs.count - 1;
                 }
+                else if (tabs.count >= (tabIndex + 1))
+                {
+                    newTabIndex = tabIndex;
+                }
+                
+                if (newTabIndex >= 0)
+                {
+                    [keyWindow performSelector:@selector(setCurrentTabViewItem:) withObject:[tabs objectAtIndex:newTabIndex]];
+                }
+                    
                 return; // prevent event dispatching
             }
         }


### PR DESCRIPTION
First, I'd like to thank you for this plugin, it may get me to use Safari again!

I'm a big fan of these shortcuts, and any tabbed app that omit them is really hard to use.

In Chrome, the `cmd-9` shortcut activates the last tab. This patch adds this behavior that I'm frequently using.

Let me know if you have any comments / suggestion and feel free to ignore this pull request if it's not something you consider useful.

Thanks for your time,

Jean-Michel
