### PR TITLE
Support for yosemite beta 5

### DIFF
--- a/SafariTabSwitching/Info.plist
+++ b/SafariTabSwitching/Info.plist
@@ -32,7 +32,7 @@
 			<key>BundleIdentifier</key>
 			<string>com.apple.Safari</string>
 			<key>MaxBundleVersion</key>
-			<string>10538.35.8</string>
+			<string>10600.1.3.41</string>
 			<key>MinBundleVersion</key>
 			<string>6533</string>
 		</dict>


### PR DESCRIPTION
Seems to run fine on beta 5, but the Safari version number changed, so it won't load it unless the max version is upped. 
