### PR TITLE
Remove Cmd-Shift-T Shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,3 @@ Usage
 Use the command + <num> keyboard shortcut to switch between the 9 first tabs of your Safari windows.
 
 NOTE: This plugin replaces the default behavior of those hotkeys which is to open the 9 first Bookmark Bar links.
-
-As a bonus, this plugin also ad Cmd+Shift+T to reopen last closed tab.

--- a/SafariTabSwitching/SafariTabSwitching.m
+++ b/SafariTabSwitching/SafariTabSwitching.m
@@ -52,22 +52,6 @@
                 return; // prevent event dispatching
             }
         }
-        
-    }
-    else if (event.type == NSKeyDown
-             && (event.modifierFlags & NSDeviceIndependentModifierFlagsMask) == (NSCommandKeyMask|NSShiftKeyMask) && event.keyCode == 0x11) { // keycode of 'T'
-
-        CGEventRef e = CGEventCreateKeyboardEvent(NULL, 0x6, YES); // keycode of 'Z'
-        
-        CGEventSetFlags(e, kCGEventFlagMaskCommand);
-        
-        NSEvent *new_event = [NSEvent eventWithCGEvent:e];
-        
-        CFRelease(e);
-        
-        [self SafariTabeSwitching_sendEvent:new_event];
-        
-        return;
     }
 
     [self SafariTabeSwitching_sendEvent:event];


### PR DESCRIPTION
Because:
- Users who wish to remap Cmd-Shift-T to Safari's "Undo Close Tab" menu item
  (providing equivalent, single-tab-reopen functionality) may do so by simply
  [assigning a keyboard shortcut](http://support.apple.com/kb/ph13916) in System Preferences -> Keyboard -> Shortcuts

And because:
- There are other Safari extensions (like [RecoverTabs](https://github.com/Antrikshy/RecoverTabs)) which provide
  more comprehensive support for Cmd-Shift-T tab-reopening, including the
  ability to reopen more than one tab
- This extension's remapping of Cmd-Shift-T breaks other in-browser Safari
  plugins that attempt to use Cmd-Shift-T

This commit:
- Reverts rs/SafariTabSwitching#15 and removes support for reopening tabs using Cmd-Shift-T.

Your choice, of course, whether to merge this. Like [other users](https://github.com/rs/SafariTabSwitching/commit/e4e16cd08da9321be2ac00992647ce29e16312cd#commitcomment-7517551), I prefer to use a different extension for Cmd-Shift-T, and I can't use your extension with it.
